### PR TITLE
fix way of sending keyword argument

### DIFF
--- a/lib/rspec/retry_ex.rb
+++ b/lib/rspec/retry_ex.rb
@@ -10,7 +10,7 @@ module RSpec
     end
 
     def retry_ex(**options)
-      handler = RetryHandler.new(options)
+      handler = RetryHandler.new(**options)
       handler.run do
         yield
       end


### PR DESCRIPTION
due to ruby 3.0 update of keyword argument, keyword argument must be send like foo(**{key: val})