### PR TITLE
Fixed a test that was failing due to Diff output.

### DIFF
--- a/lib/rspec/retry_ex/retry_handler.rb
+++ b/lib/rspec/retry_ex/retry_handler.rb
@@ -40,7 +40,7 @@ module RSpec
 
       def failure_message(error, count)
         message = "#{ordinalize(@counter)} try has failed.\n"
-        message += "=> #{error}" if @counter == count
+        message += "=>#{error}" if @counter == count
         RSpec.configuration.reporter.message(message)
       end
 

--- a/spec/lib/rspec/retry_ex_spec.rb
+++ b/spec/lib/rspec/retry_ex_spec.rb
@@ -81,10 +81,20 @@ describe RSpec::RetryEx do
         expect_any_instance_of(RSpec::Core::Reporter).to receive(:message).with(
           "1st try has failed.\n"
         )
-        expect_any_instance_of(RSpec::Core::Reporter).to receive(:message).with(
-          "2nd try has failed.\n=> \nexpected: false\n     got: true\n\n(compared using ==)\n"
-        )
+        expect_any_instance_of(RSpec::Core::Reporter).to receive(:message).with(<<~MESSAGE.chomp)
+          2nd try has failed.
+          =>
+          expected: false
+               got: true
 
+          (compared using ==)
+
+          Diff:\e[0m
+          \e[0m\e[34m@@ -1 +1 @@
+          \e[0m\e[31m-false
+          \e[0m\e[32m+true
+          \e[0m
+        MESSAGE
         # rubocop:disable Lint/HandleExceptions
         begin
           retry_ex(count: 2) do


### PR DESCRIPTION
I forked this repository and ran rspec, the error occured.

```
Failures:

  1) RSpec::RetryEx Error message when test fails should have messages
     Failure/Error: RSpec.configuration.reporter.message(message)

expected: ("2nd try has failed.\n=> \nexpected: false\n     got: true\n\n(compared using ==)\n")
     got: ("2nd try has failed.\n=> \nexpected: false\n     got: true\n\n(compared using ==)\n\nDiff:\e[0m\n\e[0m\e[34m@@ -1 +1 @@\n\e[0m\e[31m-false\n\e[0m\e[32m+true\n\e[0m")


Failed examples:

rspec ./spec/lib/rspec/retry_ex_spec.rb:80 # RSpec::RetryEx Error message when test fails should have messages
```

So I fixed that test using heredoc. 